### PR TITLE
Get region from AWS config profile

### DIFF
--- a/awscli_saml/assume_role.py
+++ b/awscli_saml/assume_role.py
@@ -30,6 +30,7 @@ def run(profile=None, region=None, session_duration=None, idp_arn=None, role_arn
     )
     principal_arn = idp_arn or config.get(section_name, "saml.idp_arn")
     role_arn = role_arn or config.get(section_name, "saml.role_arn")
+    region_name = region_name or config.get(section_name, "saml.region_name")
 
     # would use getpass, but truncates to terminal max 4096
     saml_assertion = saml or os.environ.get("SAML_ASSERTION")

--- a/awscli_saml/assume_role.py
+++ b/awscli_saml/assume_role.py
@@ -31,7 +31,7 @@ def run(profile=None, region=None, session_duration=None, idp_arn=None, role_arn
     principal_arn = idp_arn or config.get(section_name, "saml.idp_arn")
     role_arn = role_arn or config.get(section_name, "saml.role_arn")
     try:
-        region_name = region_name or config.get(section_name, "saml.region")
+        region_name = region_name or config.get(section_name, "region")
     except configparser.NoOptionError:
         pass
 

--- a/awscli_saml/assume_role.py
+++ b/awscli_saml/assume_role.py
@@ -30,7 +30,10 @@ def run(profile=None, region=None, session_duration=None, idp_arn=None, role_arn
     )
     principal_arn = idp_arn or config.get(section_name, "saml.idp_arn")
     role_arn = role_arn or config.get(section_name, "saml.role_arn")
-    region_name = region_name or config.get(section_name, "saml.region_name")
+    try:
+        region_name = region_name or config.get(section_name, "saml.region_name")
+    except configparser.NoOptionError:
+        pass
 
     # would use getpass, but truncates to terminal max 4096
     saml_assertion = saml or os.environ.get("SAML_ASSERTION")

--- a/awscli_saml/assume_role.py
+++ b/awscli_saml/assume_role.py
@@ -31,7 +31,7 @@ def run(profile=None, region=None, session_duration=None, idp_arn=None, role_arn
     principal_arn = idp_arn or config.get(section_name, "saml.idp_arn")
     role_arn = role_arn or config.get(section_name, "saml.role_arn")
     try:
-        region_name = region_name or config.get(section_name, "saml.region_name")
+        region_name = region_name or config.get(section_name, "saml.region")
     except configparser.NoOptionError:
         pass
 


### PR DESCRIPTION
Allow reading region from the user AWS config profile
Note: This was left out as part of PR #11